### PR TITLE
Add run.sh to run the application to use with alacarte

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ features:
 #### Running Ros bag Recorder
 
 ```bash
-    $ python run.py
+    $ ./run.sh
 ```
 
 ## License

--- a/initialize_project.sh
+++ b/initialize_project.sh
@@ -15,3 +15,4 @@ pip$PYTHON_SUFFIX install -r $SCRIPT_DIR/requirements.txt
 
 chmod +x $SCRIPT_DIR/.hooks/install_hooks.sh
 $SCRIPT_DIR/.hooks/install_hooks.sh
+chmod +x $SCRIPT_DIR/run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/ros/noetic/setup.bash
+source ~/catkin_fs/devel/setup.bash
+bash -c "python3 ~/ros-bag-recorder/run.py"
+
+exec $SHELL

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source /opt/ros/noetic/setup.bash
-source ~/catkin_fs/devel/setup.bash
-bash -c "python3 ~/ros-bag-recorder/run.py"
+bash -c "python3 "$SCRIPT_DIR"/run.py"
 
 exec $SHELL


### PR DESCRIPTION
alacarte package is used to add shortcuts to run applications from main menu or favorites like shown in the images
![Screenshot from 2023-06-27 21-06-16](https://github.com/asurt-fsai/ros-bag-recorder/assets/90726457/c299f0cb-5e3e-4b99-ac85-6fc6b3df37fc)
![Screenshot from 2023-06-27 21-06-58 (1)](https://github.com/asurt-fsai/ros-bag-recorder/assets/90726457/786c12d8-830e-4de3-9f32-f7b4c3354a8f)
